### PR TITLE
Fix breakOnError and breakOnWarning

### DIFF
--- a/reporters/stylish.js
+++ b/reporters/stylish.js
@@ -76,10 +76,10 @@ function Stylish (options) {
 
       // If user wants gulp to break execution on reported errors or warnings
       if (totalErrorCount && options.breakOnError) {
-        this.emit(new gutil.PluginError(PLUGIN_NAME, 'Linter errors occurred!'))
+        this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Linter errors occurred!'))
       }
       if (totalWarningCount && options.breakOnWarning) {
-        this.emit(new gutil.PluginError(PLUGIN_NAME, 'Linter warnings occurred!'))
+        this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Linter warnings occurred!'))
       }
     })
 }


### PR DESCRIPTION
There was a regression bug introduced on https://github.com/emgeee/gulp-standard/commit/1c94ef6e875fc4512364d81791412b04cc444577, so neither errors nor warnings were emitting a gulp error. Thus, it was not possible to stop gulp when the 'standard' task failed.
